### PR TITLE
Removes Default from naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ func main() {
 
     // We create a new server with wasabi.NewServer and add a channel to it with server.AddChannel. 
     // The server listens on port 8080 and the channel handles all requests to the / path.
-    channel := channel.NewDefaultChannel("/", dispatcher)
+    channel := channel.NewChannel("/", dispatcher)
     server := server.NewServer(Port)
     server.AddChannel(channel)
 

--- a/backend/http.go
+++ b/backend/http.go
@@ -65,7 +65,7 @@ func (b *HTTPBackend) Handle(conn wasabi.Connection, r wasabi.Request) error {
 	return conn.Send(wasabi.MsgTypeText, respBody.Bytes())
 }
 
-func WithDefaultHTTPTimeout(timeout time.Duration) HTTPBackendOption {
+func WithTimeout(timeout time.Duration) HTTPBackendOption {
 	return func(cfg *httpBackendConfig) {
 		cfg.defaultTimeout = timeout
 	}

--- a/backend/http_test.go
+++ b/backend/http_test.go
@@ -23,7 +23,7 @@ func TestNewBackend(t *testing.T) {
 		t.Errorf("Expected default timeout to be %v, but got %v", defaultTimeout, backend.client.Timeout)
 	}
 
-	backend = NewBackend(factory, WithDefaultHTTPTimeout(10))
+	backend = NewBackend(factory, WithTimeout(10))
 
 	if backend.client.Timeout != 10 {
 		t.Errorf("Expected default timeout to be 10, but got %v", backend.client.Timeout)

--- a/channel/channel.go
+++ b/channel/channel.go
@@ -8,11 +8,11 @@ import (
 	"nhooyr.io/websocket"
 )
 
-// DefaultChannel is default implementation of Channel
-type DefaultChannel struct {
+// Channel is default implementation of Channel
+type Channel struct {
 	path         string
 	disptacher   wasabi.Dispatcher
-	connRegistry *DefaultConnectionRegistry
+	connRegistry *ConnectionRegistry
 	ctx          context.Context
 	middlewares  []Middlewere
 	config       channelConfig
@@ -24,17 +24,17 @@ type channelConfig struct {
 
 type Option func(*channelConfig)
 
-// NewDefaultChannel creates new instance of DefaultChannel
+// NewChannel creates new instance of Channel
 // path - channel path
 // dispatcher - dispatcher to use
 // connRegistry - connection registry to use
 // reqParser - request parser to use
-// returns new instance of DefaultChannel
-func NewDefaultChannel(
+// returns new instance of Channel
+func NewChannel(
 	path string,
 	dispatcher wasabi.Dispatcher,
 	opts ...Option,
-) *DefaultChannel {
+) *Channel {
 	config := channelConfig{
 		originPatterns: []string{"*"},
 	}
@@ -43,27 +43,27 @@ func NewDefaultChannel(
 		opt(&config)
 	}
 
-	return &DefaultChannel{
+	return &Channel{
 		path:         path,
 		disptacher:   dispatcher,
-		connRegistry: NewDefaultConnectionRegistry(),
+		connRegistry: NewConnectionRegistry(),
 		middlewares:  make([]Middlewere, 0),
 		config:       config,
 	}
 }
 
 // Path returns url path for channel
-func (c *DefaultChannel) Path() string {
+func (c *Channel) Path() string {
 	return c.path
 }
 
 // Handler returns http.Handler for channel
-func (c *DefaultChannel) Handler() http.Handler {
+func (c *Channel) Handler() http.Handler {
 	return c.setContext(c.wrapMiddleware(c.wsConnectionHandler()))
 }
 
 // wsConnectionHandler handles the WebSocket connection and sets up the necessary components for communication.
-func (c *DefaultChannel) wsConnectionHandler() http.Handler {
+func (c *Channel) wsConnectionHandler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 
@@ -81,17 +81,17 @@ func (c *DefaultChannel) wsConnectionHandler() http.Handler {
 }
 
 // SetContext sets context for channel
-func (c *DefaultChannel) SetContext(ctx context.Context) {
+func (c *Channel) SetContext(ctx context.Context) {
 	c.ctx = ctx
 }
 
 // Use adds middlewere to channel
-func (c *DefaultChannel) Use(middlewere Middlewere) {
+func (c *Channel) Use(middlewere Middlewere) {
 	c.middlewares = append(c.middlewares, middlewere)
 }
 
 // useMiddleware applies middlewares to handler
-func (c *DefaultChannel) wrapMiddleware(handler http.Handler) http.Handler {
+func (c *Channel) wrapMiddleware(handler http.Handler) http.Handler {
 	for i := len(c.middlewares) - 1; i >= 0; i-- {
 		handler = c.middlewares[i](handler)
 	}
@@ -100,7 +100,7 @@ func (c *DefaultChannel) wrapMiddleware(handler http.Handler) http.Handler {
 }
 
 // setContext sets context for handler
-func (c *DefaultChannel) setContext(next http.Handler) http.Handler {
+func (c *Channel) setContext(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		next.ServeHTTP(w, r.WithContext(c.ctx))
 	})

--- a/channel/channel_test.go
+++ b/channel/channel_test.go
@@ -9,11 +9,11 @@ import (
 	"github.com/ksysoev/wasabi/mocks"
 )
 
-func TestNewDefaultChannel(t *testing.T) {
+func TestNewChannel(t *testing.T) {
 	path := "/test/path"
 	dispatcher := mocks.NewMockDispatcher(t)
 
-	channel := NewDefaultChannel(path, dispatcher)
+	channel := NewChannel(path, dispatcher)
 
 	if channel.path != path {
 		t.Errorf("Unexpected path: got %q, expected %q", channel.path, path)
@@ -27,21 +27,21 @@ func TestNewDefaultChannel(t *testing.T) {
 		t.Errorf("Unexpected number of middlewares: got %d, expected %d", len(channel.middlewares), 0)
 	}
 }
-func TestDefaultChannel_Path(t *testing.T) {
+func TestChannel_Path(t *testing.T) {
 	path := "/test/path"
 	dispatcher := mocks.NewMockDispatcher(t)
 
-	channel := NewDefaultChannel(path, dispatcher)
+	channel := NewChannel(path, dispatcher)
 
 	if channel.Path() != path {
 		t.Errorf("Unexpected path: got %q, expected %q", channel.Path(), path)
 	}
 }
-func TestDefaultChannel_Handler(t *testing.T) {
+func TestChannel_Handler(t *testing.T) {
 	path := "/test/path"
 	dispatcher := mocks.NewMockDispatcher(t)
 
-	channel := NewDefaultChannel(path, dispatcher)
+	channel := NewChannel(path, dispatcher)
 	channel.SetContext(context.Background())
 
 	// Call the Handler method
@@ -51,11 +51,11 @@ func TestDefaultChannel_Handler(t *testing.T) {
 		t.Errorf("Unexpected nil handler")
 	}
 }
-func TestDefaultChannel_SetContext(t *testing.T) {
+func TestChannel_SetContext(t *testing.T) {
 	path := "/test/path"
 	dispatcher := mocks.NewMockDispatcher(t)
 
-	channel := NewDefaultChannel(path, dispatcher)
+	channel := NewChannel(path, dispatcher)
 
 	ctx := context.Background()
 	channel.SetContext(ctx)
@@ -64,11 +64,11 @@ func TestDefaultChannel_SetContext(t *testing.T) {
 		t.Errorf("Unexpected context: got %v, expected %v", channel.ctx, ctx)
 	}
 }
-func TestDefaultChannel_Use(t *testing.T) {
+func TestChannel_Use(t *testing.T) {
 	path := "/test/path"
 	dispatcher := mocks.NewMockDispatcher(t)
 
-	channel := NewDefaultChannel(path, dispatcher)
+	channel := NewChannel(path, dispatcher)
 
 	middleware := func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -83,11 +83,11 @@ func TestDefaultChannel_Use(t *testing.T) {
 	}
 }
 
-func TestDefaultChannel_wrapMiddleware(t *testing.T) {
+func TestChannel_wrapMiddleware(t *testing.T) {
 	path := "/test/path"
 	dispatcher := mocks.NewMockDispatcher(t)
 
-	channel := NewDefaultChannel(path, dispatcher)
+	channel := NewChannel(path, dispatcher)
 
 	// Create a mock handler
 	mockHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -118,11 +118,11 @@ func TestDefaultChannel_wrapMiddleware(t *testing.T) {
 		t.Errorf("Unexpected nil wrappedHandler")
 	}
 }
-func TestDefaultChannel_SetContextMiddleware(t *testing.T) {
+func TestChannel_SetContextMiddleware(t *testing.T) {
 	path := "/test/path"
 	dispatcher := mocks.NewMockDispatcher(t)
 
-	channel := NewDefaultChannel(path, dispatcher)
+	channel := NewChannel(path, dispatcher)
 
 	// Create a mock handler
 	var ctx context.Context
@@ -152,11 +152,11 @@ func TestDefaultChannel_SetContextMiddleware(t *testing.T) {
 	}
 }
 
-func TestDefaultChannel_WithOriginPatterns(t *testing.T) {
+func TestChannel_WithOriginPatterns(t *testing.T) {
 	path := "/test/path"
 	dispatcher := mocks.NewMockDispatcher(t)
 
-	channel := NewDefaultChannel(path, dispatcher)
+	channel := NewChannel(path, dispatcher)
 
 	if len(channel.config.originPatterns) != 1 {
 		t.Errorf("Unexpected number of origin patterns: got %d, expected %d", len(channel.config.originPatterns), 1)
@@ -166,7 +166,7 @@ func TestDefaultChannel_WithOriginPatterns(t *testing.T) {
 		t.Errorf("Unexpected to get default origin pattern: got %s, expected %s", channel.config.originPatterns[0], "*")
 	}
 
-	channel = NewDefaultChannel(path, dispatcher, WithOriginPatterns("test", "test2"))
+	channel = NewChannel(path, dispatcher, WithOriginPatterns("test", "test2"))
 
 	if len(channel.config.originPatterns) != 2 {
 		t.Errorf("Unexpected number of origin patterns: got %d, expected %d", len(channel.config.originPatterns), 1)

--- a/channel/connection_registry.go
+++ b/channel/connection_registry.go
@@ -9,12 +9,12 @@ import (
 )
 
 const (
-	DefaultConcurencyLimitPerConnection = 25
-	FrameSizeLimitInBytes               = 32768
+	concurencyLimitPerConnection = 25
+	frameSizeLimitInBytes        = 32768
 )
 
-// DefaultConnectionRegistry is default implementation of ConnectionRegistry
-type DefaultConnectionRegistry struct {
+// ConnectionRegistry is default implementation of ConnectionRegistry
+type ConnectionRegistry struct {
 	connections      map[string]wasabi.Connection
 	onClose          chan string
 	bufferPool       *bufferPool
@@ -23,16 +23,16 @@ type DefaultConnectionRegistry struct {
 	frameSizeLimit   int64
 }
 
-type ConnectionRegistryOption func(*DefaultConnectionRegistry)
+type ConnectionRegistryOption func(*ConnectionRegistry)
 
-// NewDefaultConnectionRegistry creates new instance of DefaultConnectionRegistry
-func NewDefaultConnectionRegistry(opts ...ConnectionRegistryOption) *DefaultConnectionRegistry {
-	reg := &DefaultConnectionRegistry{
+// NewConnectionRegistry creates new instance of ConnectionRegistry
+func NewConnectionRegistry(opts ...ConnectionRegistryOption) *ConnectionRegistry {
+	reg := &ConnectionRegistry{
 		connections:      make(map[string]wasabi.Connection),
 		onClose:          make(chan string),
-		concurrencyLimit: DefaultConcurencyLimitPerConnection,
+		concurrencyLimit: concurencyLimitPerConnection,
 		bufferPool:       newBufferPool(),
-		frameSizeLimit:   FrameSizeLimitInBytes,
+		frameSizeLimit:   frameSizeLimitInBytes,
 	}
 
 	for _, opt := range opts {
@@ -45,7 +45,7 @@ func NewDefaultConnectionRegistry(opts ...ConnectionRegistryOption) *DefaultConn
 }
 
 // AddConnection adds new Websocket connection to registry
-func (r *DefaultConnectionRegistry) AddConnection(
+func (r *ConnectionRegistry) AddConnection(
 	ctx context.Context,
 	ws *websocket.Conn,
 	cb wasabi.OnMessage,
@@ -62,7 +62,7 @@ func (r *DefaultConnectionRegistry) AddConnection(
 }
 
 // GetConnection returns connection by id
-func (r *DefaultConnectionRegistry) GetConnection(id string) wasabi.Connection {
+func (r *ConnectionRegistry) GetConnection(id string) wasabi.Connection {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
@@ -70,7 +70,7 @@ func (r *DefaultConnectionRegistry) GetConnection(id string) wasabi.Connection {
 }
 
 // handleClose handles connection cloasures and removes them from registry
-func (r *DefaultConnectionRegistry) handleClose() {
+func (r *ConnectionRegistry) handleClose() {
 	for id := range r.onClose {
 		r.mu.Lock()
 		delete(r.connections, id)
@@ -80,12 +80,12 @@ func (r *DefaultConnectionRegistry) handleClose() {
 
 // WithMaxFrameLimit sets the maximum frame size limit for incomming messages to the ConnectionRegistry.
 // The limit parameter specifies the maximum frame size limit in bytes.
-// This option can be used when creating a new DefaultConnectionRegistry instance.
+// This option can be used when creating a new ConnectionRegistry instance.
 // The default frame size limit is 32768 bytes.
 // If the limit is set to -1, the frame size limit is disabled.
 // When the frame size limit is exceeded, the connection is closed with status 1009 (message too large).
 func WithMaxFrameLimit(limit int64) ConnectionRegistryOption {
-	return func(r *DefaultConnectionRegistry) {
+	return func(r *ConnectionRegistry) {
 		r.frameSizeLimit = limit
 	}
 }

--- a/channel/connection_registry_test.go
+++ b/channel/connection_registry_test.go
@@ -11,7 +11,7 @@ import (
 	"nhooyr.io/websocket"
 )
 
-func TestDefaultConnectionRegistry_AddConnection(t *testing.T) {
+func TestConnectionRegistry_AddConnection(t *testing.T) {
 	server := httptest.NewServer(wsHandlerEcho)
 	defer server.Close()
 	url := "ws://" + server.Listener.Addr().String()
@@ -30,7 +30,7 @@ func TestDefaultConnectionRegistry_AddConnection(t *testing.T) {
 
 	cb := func(wasabi.Connection, wasabi.MessageType, []byte) {}
 
-	registry := NewDefaultConnectionRegistry()
+	registry := NewConnectionRegistry()
 
 	conn := registry.AddConnection(ctx, ws, cb)
 
@@ -43,8 +43,8 @@ func TestDefaultConnectionRegistry_AddConnection(t *testing.T) {
 	}
 }
 
-func TestDefaultConnectionRegistry_GetConnection(t *testing.T) {
-	registry := NewDefaultConnectionRegistry()
+func TestConnectionRegistry_GetConnection(t *testing.T) {
+	registry := NewConnectionRegistry()
 
 	conn := mocks.NewMockConnection(t)
 	conn.EXPECT().ID().Return("testID")
@@ -62,8 +62,8 @@ func TestDefaultConnectionRegistry_GetConnection(t *testing.T) {
 	}
 }
 
-func TestDefaultConnectionRegistry_handleClose(t *testing.T) {
-	registry := NewDefaultConnectionRegistry()
+func TestConnectionRegistry_handleClose(t *testing.T) {
+	registry := NewConnectionRegistry()
 
 	conn := mocks.NewMockConnection(t)
 	conn.EXPECT().ID().Return("testID")
@@ -88,8 +88,8 @@ func TestDefaultConnectionRegistry_handleClose(t *testing.T) {
 	}
 }
 
-func TestDefaultConnectionRegistry_WithMaxFrameLimit(t *testing.T) {
-	registry := NewDefaultConnectionRegistry(WithMaxFrameLimit(100))
+func TestConnectionRegistry_WithMaxFrameLimit(t *testing.T) {
+	registry := NewConnectionRegistry(WithMaxFrameLimit(100))
 
 	if registry.frameSizeLimit != 100 {
 		t.Errorf("Unexpected frame size limit: got %d, expected %d", registry.frameSizeLimit, 100)

--- a/dispatch/router_dipatcher_test.go
+++ b/dispatch/router_dipatcher_test.go
@@ -58,7 +58,7 @@ func TestRouterDispatcher_AddBackend(t *testing.T) {
 	}
 }
 
-func TestRouterDispatcher_DispatchDefault(t *testing.T) {
+func TestRouterDispatcher_Dispatch(t *testing.T) {
 	defaultBackend := mocks.NewMockBackend(t)
 
 	req := mocks.NewMockRequest(t)

--- a/dispatch/router_dipatcher_test.go
+++ b/dispatch/router_dipatcher_test.go
@@ -58,7 +58,7 @@ func TestRouterDispatcher_AddBackend(t *testing.T) {
 	}
 }
 
-func TestRouterDispatcher_Dispatch(t *testing.T) {
+func TestRouterDispatcher_DispatchDefaultBackend(t *testing.T) {
 	defaultBackend := mocks.NewMockBackend(t)
 
 	req := mocks.NewMockRequest(t)

--- a/examples/http_backend/main.go
+++ b/examples/http_backend/main.go
@@ -40,7 +40,7 @@ func main() {
 	dispatcher.Use(ErrHandler)
 	dispatcher.Use(request.NewTrottlerMiddleware(10))
 
-	channel := channel.NewDefaultChannel("/", dispatcher, channel.WithOriginPatterns("*"))
+	channel := channel.NewChannel("/", dispatcher, channel.WithOriginPatterns("*"))
 
 	server := server.NewServer(Port)
 	server.AddChannel(channel)


### PR DESCRIPTION
Improves names of public structures. Default doesn't carry much meaning and removing it will make publicly available structure more clear. address #10 