### PR TITLE
Refactors context usage

### DIFF
--- a/channel/channel.go
+++ b/channel/channel.go
@@ -1,7 +1,6 @@
 package channel
 
 import (
-	"context"
 	"net/http"
 
 	"github.com/ksysoev/wasabi"
@@ -13,7 +12,6 @@ type Channel struct {
 	path         string
 	disptacher   wasabi.Dispatcher
 	connRegistry wasabi.ConnectionRegistry
-	ctx          context.Context
 	middlewares  []Middlewere
 	config       channelConfig
 }
@@ -60,7 +58,7 @@ func (c *Channel) Path() string {
 
 // Handler returns http.Handler for channel
 func (c *Channel) Handler() http.Handler {
-	return c.setContext(c.wrapMiddleware(c.wsConnectionHandler()))
+	return c.wrapMiddleware(c.wsConnectionHandler())
 }
 
 // wsConnectionHandler handles the WebSocket connection and sets up the necessary components for communication.
@@ -81,11 +79,6 @@ func (c *Channel) wsConnectionHandler() http.Handler {
 	})
 }
 
-// SetContext sets context for channel
-func (c *Channel) SetContext(ctx context.Context) {
-	c.ctx = ctx
-}
-
 // Use adds middlewere to channel
 func (c *Channel) Use(middlewere Middlewere) {
 	c.middlewares = append(c.middlewares, middlewere)
@@ -98,13 +91,6 @@ func (c *Channel) wrapMiddleware(handler http.Handler) http.Handler {
 	}
 
 	return handler
-}
-
-// setContext sets context for handler
-func (c *Channel) setContext(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		next.ServeHTTP(w, r.WithContext(c.ctx))
-	})
 }
 
 // WithOriginPatterns sets the origin patterns for the channel.

--- a/channel/channel_test.go
+++ b/channel/channel_test.go
@@ -1,9 +1,7 @@
 package channel
 
 import (
-	"context"
 	"net/http"
-	"net/http/httptest"
 	"testing"
 
 	"github.com/ksysoev/wasabi/mocks"
@@ -42,7 +40,6 @@ func TestChannel_Handler(t *testing.T) {
 	dispatcher := mocks.NewMockDispatcher(t)
 
 	channel := NewChannel(path, dispatcher, NewConnectionRegistry())
-	channel.SetContext(context.Background())
 
 	// Call the Handler method
 	handler := channel.Handler()
@@ -51,19 +48,7 @@ func TestChannel_Handler(t *testing.T) {
 		t.Errorf("Unexpected nil handler")
 	}
 }
-func TestChannel_SetContext(t *testing.T) {
-	path := "/test/path"
-	dispatcher := mocks.NewMockDispatcher(t)
 
-	channel := NewChannel(path, dispatcher, NewConnectionRegistry())
-
-	ctx := context.Background()
-	channel.SetContext(ctx)
-
-	if channel.ctx != ctx {
-		t.Errorf("Unexpected context: got %v, expected %v", channel.ctx, ctx)
-	}
-}
 func TestChannel_Use(t *testing.T) {
 	path := "/test/path"
 	dispatcher := mocks.NewMockDispatcher(t)
@@ -116,39 +101,6 @@ func TestChannel_wrapMiddleware(t *testing.T) {
 	// Assert that the wrappedHandler is the result of applying the middlewares to the mockHandler
 	if wrappedHandler == nil {
 		t.Errorf("Unexpected nil wrappedHandler")
-	}
-}
-func TestChannel_SetContextMiddleware(t *testing.T) {
-	path := "/test/path"
-	dispatcher := mocks.NewMockDispatcher(t)
-
-	channel := NewChannel(path, dispatcher, NewConnectionRegistry())
-
-	// Create a mock handler
-	var ctx context.Context
-
-	mockHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ctx = r.Context()
-	})
-
-	// Create a mock request
-	mockRequest := httptest.NewRequest(http.MethodGet, "/", http.NoBody)
-
-	// Create a mock response recorder
-	mockResponseRecorder := httptest.NewRecorder()
-
-	// Set the context for the channel
-	channel.SetContext(context.WithValue(context.Background(), struct{ key string }{"test"}, "test"))
-
-	// Wrap the mock handler with the setContext middleware
-	wrappedHandler := channel.setContext(mockHandler)
-
-	// Call the wrappedHandler with the mock request and response recorder
-	wrappedHandler.ServeHTTP(mockResponseRecorder, mockRequest)
-
-	// Assert that the context of the request is set to the channel's context
-	if ctx != channel.ctx {
-		t.Errorf("Unexpected context: got %v, expected %v", ctx, channel.ctx)
 	}
 }
 

--- a/examples/http_backend/main.go
+++ b/examples/http_backend/main.go
@@ -42,7 +42,7 @@ func main() {
 
 	channel := channel.NewChannel("/", dispatcher, channel.NewConnectionRegistry(), channel.WithOriginPatterns("*"))
 
-	server := server.NewServer(Addr)
+	server := server.NewServer(Addr, server.WithBaseContext(context.Background()))
 	server.AddChannel(channel)
 
 	if err := server.Run(); err != nil {

--- a/examples/http_backend/main.go
+++ b/examples/http_backend/main.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	Port = 8080
+	Addr = ":8080"
 )
 
 func main() {
@@ -42,10 +42,10 @@ func main() {
 
 	channel := channel.NewChannel("/", dispatcher, channel.NewConnectionRegistry(), channel.WithOriginPatterns("*"))
 
-	server := server.NewServer(Port)
+	server := server.NewServer(Addr)
 	server.AddChannel(channel)
 
-	if err := server.Run(context.Background()); err != nil {
+	if err := server.Run(); err != nil {
 		slog.Error("Fail to start app server", "error", err)
 		os.Exit(1)
 	}

--- a/interfaces.go
+++ b/interfaces.go
@@ -50,7 +50,6 @@ type RequestHandler interface {
 // Channel is interface for channels
 type Channel interface {
 	Path() string
-	SetContext(ctx context.Context)
 	Handler() http.Handler
 }
 

--- a/server/server.go
+++ b/server/server.go
@@ -18,19 +18,19 @@ const (
 )
 
 type Server struct {
-	mutex    *sync.Mutex
-	channels []wasabi.Channel
-	addr     string
-	http     *http.Server
 	baseCtx  context.Context
+	mutex    *sync.Mutex
+	http     *http.Server
+	addr     string
+	channels []wasabi.Channel
 }
 
-type ServerOption func(*Server)
+type Option func(*Server)
 
 // NewServer creates new instance of Wasabi server
 // port - port to listen on
 // returns new instance of Server
-func NewServer(addr string, opts ...ServerOption) *Server {
+func NewServer(addr string, opts ...Option) *Server {
 	server := &Server{
 		addr:     addr,
 		channels: make([]wasabi.Channel, 0, 1),
@@ -50,9 +50,9 @@ func (s *Server) AddChannel(channel wasabi.Channel) {
 	s.channels = append(s.channels, channel)
 }
 
-// Run starts server
-// ctx - context
-// returns error if any
+// Run starts the server
+// returns error if server is already running
+// or if server fails to start
 func (s *Server) Run() error {
 	if !s.mutex.TryLock() {
 		return fmt.Errorf("server is already running")
@@ -86,7 +86,7 @@ func (s *Server) Run() error {
 
 // BaseContext optionally specifies based context that will be used for all connections.
 // If not specified, context.Background() will be used.
-func WithBaseContext(ctx context.Context) ServerOption {
+func WithBaseContext(ctx context.Context) Option {
 	if ctx == nil {
 		panic("nil context")
 	}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -68,6 +68,12 @@ func TestServer_Run(t *testing.T) {
 	// Create a new Server instance
 	server := NewServer(":0")
 
+	channel := mocks.NewMockChannel(t)
+	channel.EXPECT().Path().Return("/test")
+	channel.EXPECT().Handler().Return(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+
+	server.AddChannel(channel)
+
 	// Run the server
 	done := make(chan struct{})
 	go func() {
@@ -78,9 +84,13 @@ func TestServer_Run(t *testing.T) {
 		close(done)
 	}()
 
-	<-time.After(100 * time.Millisecond)
+	<-time.After(50 * time.Millisecond)
 
-	if err := server.http.Close(); err != nil {
+	if err := server.Run(); err != ErrServerAlreadyRunning {
+		t.Errorf("Expected error %v, but got %v", ErrServerAlreadyRunning, err)
+	}
+
+	if err := server.handler.Close(); err != nil {
 		t.Errorf("Expected no error, but got %v", err)
 	}
 


### PR DESCRIPTION
Changing the way we distribute context through the components, instead of assigning context at channel, I decided to use base context of http server. 