### PR TITLE
Implement connection hooks logic

### DIFF
--- a/channel/connection_registry.go
+++ b/channel/connection_registry.go
@@ -172,19 +172,19 @@ func WithInActivityTimeout(timeout time.Duration) ConnectionRegistryOption {
 	}
 }
 
-// WithOnConnect sets the connection hook function that will be called when a new connection is established.
+// WithOnConnectHook sets the connection hook function that will be called when a new connection is established.
 // The provided callback function `cb` will be invoked with the newly established connection as its argument.
 // This function returns a ConnectionRegistryOption that can be used to configure a ConnectionRegistry.
-func WithOnConnect(cb ConnectionHook) ConnectionRegistryOption {
+func WithOnConnectHook(cb ConnectionHook) ConnectionRegistryOption {
 	return func(r *ConnectionRegistry) {
 		r.onConnect = cb
 	}
 }
 
-// WithOnDisconnect sets the callback function to be executed when a connection is disconnected.
+// WithOnDisconnectHook sets the callback function to be executed when a connection is disconnected.
 // The provided callback function should have the signature `func(connectionID string)`.
 // It can be used to perform any necessary cleanup or logging operations when a connection is disconnected.
-func WithOnDisconnect(cb ConnectionHook) ConnectionRegistryOption {
+func WithOnDisconnectHook(cb ConnectionHook) ConnectionRegistryOption {
 	return func(r *ConnectionRegistry) {
 		r.onDisconnect = cb
 	}

--- a/channel/connection_registry.go
+++ b/channel/connection_registry.go
@@ -100,8 +100,8 @@ func (r *ConnectionRegistry) handleClose() {
 			wg.Add(1)
 
 			go func() {
+				defer wg.Done()
 				r.onDisconnect(connection)
-				wg.Done()
 			}()
 		}
 	}

--- a/channel/connection_registry_test.go
+++ b/channel/connection_registry_test.go
@@ -44,6 +44,36 @@ func TestConnectionRegistry_AddConnection(t *testing.T) {
 	}
 }
 
+func TestConnectionRegistry_AddConnection_ToClosedRegistry(t *testing.T) {
+	registry := NewConnectionRegistry()
+
+	registry.Close()
+
+	server := httptest.NewServer(wsHandlerEcho)
+	defer server.Close()
+	url := "ws://" + server.Listener.Addr().String()
+
+	ws, resp, err := websocket.Dial(context.Background(), url, nil)
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	if resp.Body != nil {
+		resp.Body.Close()
+	}
+
+	ctx := context.Background()
+
+	cb := func(wasabi.Connection, wasabi.MessageType, []byte) {}
+
+	conn := registry.AddConnection(ctx, ws, cb)
+
+	if conn != nil {
+		t.Error("Expected connection to be nil")
+	}
+}
+
 func TestConnectionRegistry_GetConnection(t *testing.T) {
 	registry := NewConnectionRegistry()
 

--- a/channel/connection_registry_test.go
+++ b/channel/connection_registry_test.go
@@ -151,3 +151,45 @@ func TestConnectionRegistry_WithInActivityTimeout(t *testing.T) {
 		t.Errorf("Unexpected inactivity timeout: got %s, expected %s", registry.inActivityTimeout, 5*time.Minute)
 	}
 }
+func TestConnectionRegistry_WithOnConnect(t *testing.T) {
+	registry := NewConnectionRegistry()
+
+	if registry.onConnect != nil {
+		t.Error("Expected onConnect callback to be nil")
+	}
+
+	server := httptest.NewServer(wsHandlerEcho)
+	defer server.Close()
+	url := "ws://" + server.Listener.Addr().String()
+
+	ws, resp, err := websocket.Dial(context.Background(), url, nil)
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	if resp.Body != nil {
+		resp.Body.Close()
+	}
+
+	executed := false
+	cb := func(conn wasabi.Connection) {
+		if conn == nil {
+			t.Error("Expected connection to be passed to onConnect callback")
+		}
+
+		executed = true
+	}
+
+	registry = NewConnectionRegistry(WithOnConnect(cb))
+
+	if registry.onConnect == nil {
+		t.Error("Expected onConnect callback to be set")
+	}
+
+	registry.AddConnection(context.Background(), ws, func(wasabi.Connection, wasabi.MessageType, []byte) {})
+
+	if !executed {
+		t.Error("Expected onConnect callback to be executed")
+	}
+}


### PR DESCRIPTION
This pull request adds the implementation of connection hooks logic to the ConnectionRegistry. It introduces two new options, `WithOnConnect` and `WithOnDisconnect`, which allow users to set callback functions that will be executed when a new connection is established or when a connection is disconnected, respectively. This feature provides flexibility for performing additional operations or handling events related to connections.