### PR TITLE
Implement connection wrapper logic

### DIFF
--- a/channel/connection_wrapper.go
+++ b/channel/connection_wrapper.go
@@ -1,0 +1,71 @@
+package channel
+
+import (
+	"context"
+
+	"github.com/ksysoev/wasabi"
+	"nhooyr.io/websocket"
+)
+
+type WrapperOptions func(*ConnectionWrapper)
+
+type SendWrapper func(conn wasabi.Connection, msgType wasabi.MessageType, msg []byte) error
+type CloseWrapper func(conn wasabi.Connection, status websocket.StatusCode, reason string, closingCtx ...context.Context) error
+
+type ConnectionWrapper struct {
+	connection     wasabi.Connection
+	onSendWrapper  SendWrapper
+	onCloseWrapper CloseWrapper
+}
+
+func NewConnectionWrapper(connection wasabi.Connection, opts ...WrapperOptions) *ConnectionWrapper {
+	wrapper := &ConnectionWrapper{
+		connection: connection,
+	}
+
+	for _, opt := range opts {
+		opt(wrapper)
+	}
+
+	return wrapper
+}
+
+func (cw *ConnectionWrapper) ID() string {
+	return cw.connection.ID()
+}
+
+func (cw *ConnectionWrapper) Context() context.Context {
+	return cw.connection.Context()
+}
+
+func (cw *ConnectionWrapper) HandleRequests() {
+	cw.connection.HandleRequests()
+}
+
+func (cw *ConnectionWrapper) Send(msgType wasabi.MessageType, msg []byte) error {
+	if cw.onSendWrapper != nil {
+		return cw.onSendWrapper(cw.connection, msgType, msg)
+	}
+
+	return cw.connection.Send(msgType, msg)
+}
+
+func (cw *ConnectionWrapper) Close(status websocket.StatusCode, reason string, closingCtx ...context.Context) error {
+	if cw.onCloseWrapper != nil {
+		return cw.onCloseWrapper(cw.connection, status, reason, closingCtx...)
+	}
+
+	return cw.connection.Close(status, reason, closingCtx...)
+}
+
+func WithSendWrapper(wrapper SendWrapper) WrapperOptions {
+	return func(cw *ConnectionWrapper) {
+		cw.onSendWrapper = wrapper
+	}
+}
+
+func WithCloseWrapper(wrapper CloseWrapper) WrapperOptions {
+	return func(cw *ConnectionWrapper) {
+		cw.onCloseWrapper = wrapper
+	}
+}

--- a/channel/connection_wrapper.go
+++ b/channel/connection_wrapper.go
@@ -7,17 +7,25 @@ import (
 	"nhooyr.io/websocket"
 )
 
+// WrapperOptions is a function type that represents options for configuring a ConnectionWrapper.
+// It is used to modify the behavior of the ConnectionWrapper by applying various options.
 type WrapperOptions func(*ConnectionWrapper)
 
+// SendWrapper is a function type that wraps the Send method of a ConnectionWrapper.
 type SendWrapper func(conn wasabi.Connection, msgType wasabi.MessageType, msg []byte) error
+
+// CloseWrapper is a function type that wraps the Close method of a ConnectionWrapper.
 type CloseWrapper func(conn wasabi.Connection, status websocket.StatusCode, reason string, closingCtx ...context.Context) error
 
+// ConnectionWrapper is a wrapper around a wasabi.Connection that allows for custom behavior to be applied to the connection.
 type ConnectionWrapper struct {
 	connection     wasabi.Connection
 	onSendWrapper  SendWrapper
 	onCloseWrapper CloseWrapper
 }
 
+// NewConnectionWrapper creates a new ConnectionWrapper instance with the given connection and options.
+// It applies the provided WrapperOptions to the wrapper before returning it.
 func NewConnectionWrapper(connection wasabi.Connection, opts ...WrapperOptions) *ConnectionWrapper {
 	wrapper := &ConnectionWrapper{
 		connection: connection,
@@ -30,18 +38,26 @@ func NewConnectionWrapper(connection wasabi.Connection, opts ...WrapperOptions) 
 	return wrapper
 }
 
+// ID returns the ID of the ConnectionWrapper.
 func (cw *ConnectionWrapper) ID() string {
 	return cw.connection.ID()
 }
 
+// Context returns the context associated with the connection wrapper.
 func (cw *ConnectionWrapper) Context() context.Context {
 	return cw.connection.Context()
 }
 
+// HandleRequests handles incoming requests on the connection.
 func (cw *ConnectionWrapper) HandleRequests() {
 	cw.connection.HandleRequests()
 }
 
+// Send sends a message of the specified type and content over the connection.
+// If an onSendWrapper function is set, it will be called instead of directly sending the message.
+// The onSendWrapper function should have the signature func(connection Connection, msgType MessageType, msg []byte) error.
+// If there is no onSendWrapper function set, the message will be sent directly using the underlying connection.
+// Returns an error if there was a problem sending the message.
 func (cw *ConnectionWrapper) Send(msgType wasabi.MessageType, msg []byte) error {
 	if cw.onSendWrapper != nil {
 		return cw.onSendWrapper(cw.connection, msgType, msg)
@@ -50,6 +66,10 @@ func (cw *ConnectionWrapper) Send(msgType wasabi.MessageType, msg []byte) error 
 	return cw.connection.Send(msgType, msg)
 }
 
+// Close closes the connection with the specified status code and reason.
+// It also accepts an optional closing context.
+// If an onCloseWrapper function is set, it will be called instead of directly closing the connection.
+// The onCloseWrapper function should have the same signature as the Connection.Close method.
 func (cw *ConnectionWrapper) Close(status websocket.StatusCode, reason string, closingCtx ...context.Context) error {
 	if cw.onCloseWrapper != nil {
 		return cw.onCloseWrapper(cw.connection, status, reason, closingCtx...)
@@ -58,12 +78,16 @@ func (cw *ConnectionWrapper) Close(status websocket.StatusCode, reason string, c
 	return cw.connection.Close(status, reason, closingCtx...)
 }
 
+// WithSendWrapper returns a WrapperOptions function that sets the onSendWrapper
+// field of the ConnectionWrapper to the provided wrapper.
 func WithSendWrapper(wrapper SendWrapper) WrapperOptions {
 	return func(cw *ConnectionWrapper) {
 		cw.onSendWrapper = wrapper
 	}
 }
 
+// WithCloseWrapper returns a WrapperOptions function that sets the onCloseWrapper
+// field of the ConnectionWrapper to the provided wrapper.
 func WithCloseWrapper(wrapper CloseWrapper) WrapperOptions {
 	return func(cw *ConnectionWrapper) {
 		cw.onCloseWrapper = wrapper

--- a/channel/connection_wrapper_test.go
+++ b/channel/connection_wrapper_test.go
@@ -1,0 +1,169 @@
+package channel
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ksysoev/wasabi"
+	"github.com/ksysoev/wasabi/mocks"
+	"github.com/stretchr/testify/assert"
+	"nhooyr.io/websocket"
+)
+
+func TestNewConnectionWrapper(t *testing.T) {
+	mockConnection := mocks.NewMockConnection(t)
+
+	wrapper := NewConnectionWrapper(mockConnection)
+
+	assert.NotNil(t, wrapper)
+	assert.Equal(t, mockConnection, wrapper.connection)
+}
+
+func TestConnectionWrapper_ID(t *testing.T) {
+	mockConnection := mocks.NewMockConnection(t)
+	wrapper := NewConnectionWrapper(mockConnection)
+
+	expectedID := "testID"
+	mockConnection.On("ID").Return(expectedID)
+
+	actualID := wrapper.ID()
+
+	assert.Equal(t, expectedID, actualID)
+}
+
+func TestConnectionWrapper_Context(t *testing.T) {
+	mockConnection := mocks.NewMockConnection(t)
+	wrapper := NewConnectionWrapper(mockConnection)
+
+	expectedContext := context.TODO()
+	mockConnection.On("Context").Return(expectedContext)
+
+	actualContext := wrapper.Context()
+
+	assert.Equal(t, expectedContext, actualContext)
+}
+
+func TestConnectionWrapper_HandleRequests(t *testing.T) {
+	mockConnection := mocks.NewMockConnection(t)
+	wrapper := NewConnectionWrapper(mockConnection)
+
+	mockConnection.On("HandleRequests").Once()
+
+	wrapper.HandleRequests()
+
+	mockConnection.AssertExpectations(t)
+}
+func TestConnectionWrapper_Send_WithOnSendWrapper(t *testing.T) {
+	mockConnection := mocks.NewMockConnection(t)
+	wrapper := NewConnectionWrapper(mockConnection)
+
+	expectedMsgType := wasabi.MessageType(1)
+	expectedMsg := []byte("test message")
+
+	mockOnSendWrapper := func(conn wasabi.Connection, msgType wasabi.MessageType, msg []byte) error {
+		assert.Equal(t, mockConnection, conn)
+		assert.Equal(t, expectedMsgType, msgType)
+		assert.Equal(t, expectedMsg, msg)
+
+		return nil
+	}
+
+	wrapper.onSendWrapper = mockOnSendWrapper
+
+	err := wrapper.Send(expectedMsgType, expectedMsg)
+
+	assert.NoError(t, err)
+}
+
+func TestConnectionWrapper_Send_WithoutOnSendWrapper(t *testing.T) {
+	mockConnection := mocks.NewMockConnection(t)
+	wrapper := NewConnectionWrapper(mockConnection)
+
+	expectedMsgType := wasabi.MessageType(1)
+	expectedMsg := []byte("test message")
+
+	mockConnection.On("Send", expectedMsgType, expectedMsg).Return(nil)
+
+	err := wrapper.Send(expectedMsgType, expectedMsg)
+
+	assert.NoError(t, err)
+	mockConnection.AssertExpectations(t)
+}
+
+func TestConnectionWrapper_Close_WithOnCloseWrapper(t *testing.T) {
+	mockConnection := mocks.NewMockConnection(t)
+	wrapper := NewConnectionWrapper(mockConnection)
+
+	expectedStatus := websocket.StatusCode(1000)
+	expectedReason := "test reason"
+	expectedClosingCtx := context.TODO()
+
+	mockOnCloseWrapper := func(conn wasabi.Connection, status websocket.StatusCode, reason string, closingCtx ...context.Context) error {
+		assert.Equal(t, mockConnection, conn)
+		assert.Equal(t, expectedStatus, status)
+		assert.Equal(t, expectedReason, reason)
+		assert.Equal(t, expectedClosingCtx, closingCtx[0])
+
+		return nil
+	}
+
+	wrapper.onCloseWrapper = mockOnCloseWrapper
+
+	err := wrapper.Close(expectedStatus, expectedReason, expectedClosingCtx)
+
+	assert.NoError(t, err)
+}
+
+func TestConnectionWrapper_Close_WithoutOnCloseWrapper(t *testing.T) {
+	mockConnection := mocks.NewMockConnection(t)
+	wrapper := NewConnectionWrapper(mockConnection)
+
+	expectedStatus := websocket.StatusCode(1000)
+	expectedReason := "test reason"
+	expectedClosingCtx := context.TODO()
+
+	mockConnection.On("Close", expectedStatus, expectedReason, expectedClosingCtx).Return(nil)
+
+	err := wrapper.Close(expectedStatus, expectedReason, expectedClosingCtx)
+
+	assert.NoError(t, err)
+	mockConnection.AssertExpectations(t)
+}
+
+func TestConnectionWrapper_WithSendWrapper(t *testing.T) {
+	mockConnection := mocks.NewMockConnection(t)
+	wrapper := NewConnectionWrapper(mockConnection)
+
+	if wrapper.onSendWrapper != nil {
+		t.Error("Expected onSendWrapper to be nil")
+	}
+
+	cb := func(conn wasabi.Connection, msgType wasabi.MessageType, msg []byte) error {
+		return nil
+	}
+
+	wrapper = NewConnectionWrapper(mockConnection, WithSendWrapper(cb))
+
+	if wrapper.onSendWrapper == nil {
+		t.Error("Expected onSendWrapper to be set")
+	}
+}
+
+func TestConnectionWrapper_WithCloseWrapper(t *testing.T) {
+	mockConnection := mocks.NewMockConnection(t)
+	wrapper := NewConnectionWrapper(mockConnection)
+
+	if wrapper.onCloseWrapper != nil {
+		t.Error("Expected onCloseWrapper to be nil")
+	}
+
+	cb := func(conn wasabi.Connection, status websocket.StatusCode, reason string, closingCtx ...context.Context) error {
+		return nil
+	}
+
+	wrapper = NewConnectionWrapper(mockConnection, WithCloseWrapper(cb))
+
+	if wrapper.onCloseWrapper == nil {
+		t.Error("Expected onCloseWrapper to be set")
+	}
+}


### PR DESCRIPTION
This pull request adds the implementation of a connection wrapper logic. The `ConnectionWrapper` struct provides methods for sending messages and closing connections, with the ability to add custom wrappers for these operations.

Address issue #32 