### PR TITLE
Propagate WS status closure between client and server connections

### DIFF
--- a/backend/ws_test.go
+++ b/backend/ws_test.go
@@ -207,7 +207,7 @@ func TestWSBackend_Handle_CloseConnection(t *testing.T) {
 	conn.EXPECT().ID().Return("connection1")
 	conn.EXPECT().Context().Return(ctx)
 
-	conn.EXPECT().Close(websocket.StatusNormalClosure, "").Return(nil)
+	conn.EXPECT().Close(websocket.StatusNormalClosure, "connection closed").Return(nil)
 
 	b := NewWSBackend(url, func(r wasabi.Request) (websocket.MessageType, []byte, error) {
 		return websocket.MessageText, []byte("Hello, world!"), nil


### PR DESCRIPTION
This pull request includes changes to propagate the WebSocket status closure between client and server connections. It ensures that the connection is properly closed and handles the response from the server to the client. The code has been updated to handle different closure codes and reasons.