### PR TITLE
Adds possibility to get address and port that used by the server

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -21,11 +21,11 @@ var ErrServerAlreadyRunning = fmt.Errorf("server is already running")
 
 type Server struct {
 	baseCtx  context.Context
+	listener net.Listener
 	mutex    *sync.Mutex
 	handler  *http.Server
 	addr     string
 	channels []wasabi.Channel
-	listener net.Listener
 }
 
 type Option func(*Server)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -2,7 +2,6 @@ package server
 
 import (
 	"context"
-	"fmt"
 	"net/http"
 	"testing"
 	"time"
@@ -256,7 +255,8 @@ func TestServer_Addr(t *testing.T) {
 		t.Error("Expected server to start")
 	}
 
-	fmt.Println(server.listener)
+	// Wait for the server to fully start
+	time.Sleep(1 * time.Millisecond)
 
 	addr := server.Addr()
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -26,6 +26,12 @@ func TestNewServer(t *testing.T) {
 	if server.mutex == nil {
 		t.Error("Expected non-nil mutex")
 	}
+
+	server = NewServer("")
+
+	if server.addr != ":http" {
+		t.Errorf("Expected default port :http, but got %s", server.addr)
+	}
 }
 func TestServer_AddChannel(t *testing.T) {
 	// Create a new Server instance
@@ -231,6 +237,10 @@ func TestServer_Addr(t *testing.T) {
 	channel.EXPECT().Close().Return(nil)
 
 	server.AddChannel(channel)
+
+	if server.Addr() != nil {
+		t.Error("Expected nil address for server that is not running")
+	}
 
 	// Start the server in a separate goroutine
 	done := make(chan struct{})


### PR DESCRIPTION
This pull request adds a net.Listener field to the Server struct and updates the Run method to use the listener for starting the server. This change allows the server's network address to be retrieved using the new Addr method. Additionally, a new test case has been added to verify the behavior of the Addr method.