### PR TITLE
Add channel to signify server readiness

### DIFF
--- a/server/server_test.go
+++ b/server/server_test.go
@@ -244,29 +244,15 @@ func TestServer_Addr(t *testing.T) {
 
 	// Start the server in a separate goroutine
 	done := make(chan struct{})
-
-	// Run the server
-	for i := 0; i < 2; i++ {
-		go func() {
-			err := server.Run()
-			switch err {
-			case nil:
-			case ErrServerAlreadyRunning:
-				close(done)
-			default:
-				t.Errorf("Got unexpected error: %v", err)
-			}
-		}()
-	}
-
-	select {
-	case <-done:
-	case <-time.After(1 * time.Second):
-		t.Error("Expected server to start")
-	}
+	go func() {
+		err := server.Run(done)
+		if err != nil {
+			t.Errorf("Got unexpected error: %v", err)
+		}
+	}()
 
 	// Wait for the server to fully start
-	time.Sleep(1 * time.Millisecond)
+	<-done
 
 	addr := server.Addr()
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -227,7 +227,8 @@ func TestServer_Close_NoContext(t *testing.T) {
 
 func TestServer_Addr(t *testing.T) {
 	// Create a new Server instance
-	server := NewServer(":0")
+	done := make(chan struct{})
+	server := NewServer(":0", WithReadinessChan(done))
 	defer server.Close()
 
 	// Create a mock channel
@@ -243,9 +244,8 @@ func TestServer_Addr(t *testing.T) {
 	}
 
 	// Start the server in a separate goroutine
-	done := make(chan struct{})
 	go func() {
-		err := server.Run(done)
+		err := server.Run()
 		if err != nil {
 			t.Errorf("Got unexpected error: %v", err)
 		}


### PR DESCRIPTION
Added an optional channel param which can be used to signify that the server is ready to accept connection. Run function will close the channel (if supplied) when it is ready to accept connection.

User of this function can choose to wait for signal from Run function by supplying a channel of struct type, and waiting for it to return a signal. This is especially useful for tests to avoid timing the startup of server.