### PR TITLE
Optimize backend response handling and move concurrency limit

### DIFF
--- a/backend/http_test.go
+++ b/backend/http_test.go
@@ -106,3 +106,20 @@ func TestHTTPBackend_Handle_TimeoutRequestByContext(t *testing.T) {
 		t.Errorf("Expected error to be %v, but got %v", context.DeadlineExceeded, err)
 	}
 }
+func TestWithMaxRequestsPerHost(t *testing.T) {
+	maxReqPerHost := 100
+
+	backend := NewBackend(nil, WithMaxRequestsPerHost(maxReqPerHost))
+
+	if backend.client.Transport.(*http.Transport).MaxConnsPerHost != maxReqPerHost {
+		t.Errorf("Expected MaxConnsPerHost to be %v, but got %v", maxReqPerHost, backend.client.Transport.(*http.Transport).MaxConnsPerHost)
+	}
+}
+
+func TestWithMaxRequestsPerHost_DefaultValue(t *testing.T) {
+	backend := NewBackend(nil)
+
+	if backend.client.Transport.(*http.Transport).MaxConnsPerHost != defaultMaxReqPerHost {
+		t.Errorf("Expected MaxConnsPerHost to be %v, but got %v", defaultMaxReqPerHost, backend.client.Transport.(*http.Transport).MaxConnsPerHost)
+	}
+}

--- a/examples/http_backend/main.go
+++ b/examples/http_backend/main.go
@@ -11,7 +11,6 @@ import (
 	"github.com/ksysoev/wasabi/backend"
 	"github.com/ksysoev/wasabi/channel"
 	"github.com/ksysoev/wasabi/dispatch"
-	"github.com/ksysoev/wasabi/middleware/request"
 	"github.com/ksysoev/wasabi/server"
 )
 
@@ -31,16 +30,9 @@ func main() {
 		return httpReq, nil
 	})
 
-	ErrHandler := request.NewErrorHandlingMiddleware(func(conn wasabi.Connection, req wasabi.Request, err error) error {
-		conn.Send(wasabi.MsgTypeText, []byte("Failed to process request: "+err.Error()))
-		return nil
-	})
-
 	dispatcher := dispatch.NewRouterDispatcher(backend, func(conn wasabi.Connection, msgType wasabi.MessageType, data []byte) wasabi.Request {
 		return dispatch.NewRawRequest(conn.Context(), msgType, data)
 	})
-	dispatcher.Use(ErrHandler)
-	dispatcher.Use(request.NewTrottlerMiddleware(100))
 
 	channel := channel.NewChannel("/", dispatcher, channel.NewConnectionRegistry(), channel.WithOriginPatterns("*"))
 


### PR DESCRIPTION
This pull request optimizes the backend response handling by moving the concurrency limit to the backend level. It also introduces a new option, `WithMaxRequestsPerHost`, which allows setting the maximum number of requests per host. This improves the performance and scalability of the HTTP backend.

Based on local load testing now it's 8-9 times faster