### PR TITLE
"Implement connection limit for WebSocket connections"

### DIFF
--- a/interfaces.go
+++ b/interfaces.go
@@ -59,4 +59,5 @@ type ConnectionRegistry interface {
 	) Connection
 	GetConnection(id string) Connection
 	Close(ctx ...context.Context) error
+	CanAccept() bool
 }

--- a/mocks/mock_ConnectionRegistry.go
+++ b/mocks/mock_ConnectionRegistry.go
@@ -76,6 +76,51 @@ func (_c *MockConnectionRegistry_AddConnection_Call) RunAndReturn(run func(conte
 	return _c
 }
 
+// CanAccept provides a mock function with given fields:
+func (_m *MockConnectionRegistry) CanAccept() bool {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for CanAccept")
+	}
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func() bool); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
+}
+
+// MockConnectionRegistry_CanAccept_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'CanAccept'
+type MockConnectionRegistry_CanAccept_Call struct {
+	*mock.Call
+}
+
+// CanAccept is a helper method to define mock.On call
+func (_e *MockConnectionRegistry_Expecter) CanAccept() *MockConnectionRegistry_CanAccept_Call {
+	return &MockConnectionRegistry_CanAccept_Call{Call: _e.mock.On("CanAccept")}
+}
+
+func (_c *MockConnectionRegistry_CanAccept_Call) Run(run func()) *MockConnectionRegistry_CanAccept_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run()
+	})
+	return _c
+}
+
+func (_c *MockConnectionRegistry_CanAccept_Call) Return(_a0 bool) *MockConnectionRegistry_CanAccept_Call {
+	_c.Call.Return(_a0)
+	return _c
+}
+
+func (_c *MockConnectionRegistry_CanAccept_Call) RunAndReturn(run func() bool) *MockConnectionRegistry_CanAccept_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // Close provides a mock function with given fields: ctx
 func (_m *MockConnectionRegistry) Close(ctx ...context.Context) error {
 	_va := make([]interface{}, len(ctx))


### PR DESCRIPTION
This pull request adds the ability to limit the number of active WebSocket connections in the ConnectionRegistry. It introduces a new method, `CanAccept()`, which checks if the registry can accept new connections based on the specified connection limit. If the connection limit is reached, a "Connection limit reached" error message is returned. The `AddConnection()` method has been updated to check the connection limit before adding a new connection. Additionally, a new option, `WithConnectionLimit()`, has been added to set the maximum number of connections that can be accepted by the ConnectionRegistry.