### PR TITLE
Update Go version in GitHub Actions workflow to include matrix strategy

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,12 +13,15 @@ permissions:
 jobs:
   tests:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: ["1.21.x", "1.22.x"]
     steps:
       - uses: actions/checkout@v3
-      - name: Setup Go 1.21
+      - name: Setup Go ${{ matrix.go-version }}
         uses: actions/setup-go@v3
         with:
-          go-version: "1.21.x"
+          go-version: ${{ matrix.go-version }}
       - name: Display Go version
         run: go version
       - name: Code Lint


### PR DESCRIPTION
This pull request updates the Go version in the GitHub Actions workflow to include a matrix strategy. The matrix strategy allows for testing with different Go versions, specifically versions 1.21.x and 1.22.x. This change ensures that the workflow is compatible with multiple Go versions and helps to catch any potential compatibility issues.

address issue #80 