### PR TITLE
Add load balancer for backend nodes

### DIFF
--- a/backend/loadbalancer.go
+++ b/backend/loadbalancer.go
@@ -1,0 +1,62 @@
+package backend
+
+import (
+	"sync/atomic"
+
+	"github.com/ksysoev/wasabi"
+)
+
+type BackendNode struct {
+	backend wasabi.RequestHandler
+	counter atomic.Int32
+}
+
+type LoadBalancer struct {
+	backends []*BackendNode
+}
+
+// NewLoadBalancer creates a new instance of LoadBalancer with the given backends.
+// It takes a slice of RequestHandler as a parameter and returns a new instance of LoadBalancer.
+func NewLoadBalancer(backends []wasabi.RequestHandler) *LoadBalancer {
+	nodes := make([]*BackendNode, len(backends))
+
+	for i, backend := range backends {
+		nodes[i] = &BackendNode{
+			backend: backend,
+			counter: atomic.Int32{},
+		}
+	}
+
+	return &LoadBalancer{
+		backends: nodes,
+	}
+}
+
+// Handle handles the incoming request by sending it to the least busy backend and returning the response.
+// It takes a connection and a request as parameters and returns an error if any.
+func (lb *LoadBalancer) Handle(conn wasabi.Connection, r wasabi.Request) error {
+	backend := lb.getLeastBusyNode()
+
+	backend.counter.Add(1)
+	defer backend.counter.Add(-1)
+
+	return backend.backend.Handle(conn, r)
+}
+
+// getLeastBusyNode returns the least busy backend node.
+// It returns the least busy backend node.
+func (lb *LoadBalancer) getLeastBusyNode() *BackendNode {
+	var minRequests int32
+	var minBackend *BackendNode
+
+	for i := range lb.backends {
+		requests := lb.backends[i].counter.Load()
+
+		if requests < minRequests {
+			minRequests = requests
+			minBackend = lb.backends[i]
+		}
+	}
+
+	return minBackend
+}

--- a/backend/loadbalancer_test.go
+++ b/backend/loadbalancer_test.go
@@ -1,0 +1,87 @@
+package backend
+
+import (
+	"testing"
+
+	"github.com/ksysoev/wasabi"
+	"github.com/ksysoev/wasabi/mocks"
+)
+
+func TestNewLoadBalancer(t *testing.T) {
+	backends := []wasabi.RequestHandler{
+		mocks.NewMockBackend(t),
+	}
+
+	_, err := NewLoadBalancer(backends)
+	if err != ErrNotEnoughBackends {
+		t.Errorf("Expected error to be 'load balancer requires at least 2 backends', but got %v", err)
+	}
+
+	backends = append(backends, mocks.NewMockBackend(t))
+	lb, err := NewLoadBalancer(backends)
+	if err != nil {
+		t.Fatalf("Failed to create load balancer: %v", err)
+	}
+
+	if len(lb.backends) != len(backends) {
+		t.Errorf("Expected %d backends, but got %d", len(backends), len(lb.backends))
+	}
+
+	for i, backend := range lb.backends {
+		if backend.backend != backends[i] {
+			t.Errorf("Expected backend at index %d to be %v, but got %v", i, backends[i], backend.backend)
+		}
+		if backend.counter.Load() != 0 {
+			t.Errorf("Expected backend counter at index %d to be 0, but got %d", i, backend.counter.Load())
+		}
+	}
+}
+
+func TestLoadBalancer_getLeastBusyNode(t *testing.T) {
+	backends := []wasabi.RequestHandler{
+		// Mock backends for testing
+		mocks.NewMockBackend(t),
+		mocks.NewMockBackend(t),
+	}
+
+	lb, err := NewLoadBalancer(backends)
+	if err != nil {
+		t.Fatalf("Failed to create load balancer: %v", err)
+	}
+
+	// Increment the counter of the second backend
+	lb.backends[0].counter.Add(10)
+
+	// Get the least busy node
+	leastBusyNode := lb.getLeastBusyNode()
+
+	// Check if the least busy node is the second backend
+	if leastBusyNode != lb.backends[1] {
+		t.Errorf("Expected least busy node to be the second backend, but got %v", leastBusyNode)
+	}
+}
+func TestLoadBalancer_Handle(t *testing.T) {
+	firstBackend := mocks.NewMockBackend(t)
+	// Create mock backends for testing
+	backends := []wasabi.RequestHandler{
+		firstBackend,
+		mocks.NewMockBackend(t),
+		mocks.NewMockBackend(t),
+	}
+	lb, err := NewLoadBalancer(backends)
+	if err != nil {
+		t.Fatalf("Failed to create load balancer: %v", err)
+	}
+
+	// Create mock connection and request
+	mockConn := mocks.NewMockConnection(t)
+	mockRequest := mocks.NewMockRequest(t)
+
+	firstBackend.EXPECT().Handle(mockConn, mockRequest).Return(nil)
+
+	// Call the Handle method
+	err = lb.Handle(mockConn, mockRequest)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+}

--- a/backend/loadbalancer_test.go
+++ b/backend/loadbalancer_test.go
@@ -18,6 +18,7 @@ func TestNewLoadBalancer(t *testing.T) {
 	}
 
 	backends = append(backends, mocks.NewMockBackend(t))
+
 	lb, err := NewLoadBalancer(backends)
 	if err != nil {
 		t.Fatalf("Failed to create load balancer: %v", err)
@@ -31,6 +32,7 @@ func TestNewLoadBalancer(t *testing.T) {
 		if backend.backend != backends[i] {
 			t.Errorf("Expected backend at index %d to be %v, but got %v", i, backends[i], backend.backend)
 		}
+
 		if backend.counter.Load() != 0 {
 			t.Errorf("Expected backend counter at index %d to be 0, but got %d", i, backend.counter.Load())
 		}
@@ -68,6 +70,7 @@ func TestLoadBalancer_Handle(t *testing.T) {
 		mocks.NewMockBackend(t),
 		mocks.NewMockBackend(t),
 	}
+
 	lb, err := NewLoadBalancer(backends)
 	if err != nil {
 		t.Fatalf("Failed to create load balancer: %v", err)


### PR DESCRIPTION
This pull request adds a load balancer for backend nodes. It includes the following changes:

- Added a `LoadBalancerNode` struct to represent each backend node.

- Refactored the `LoadBalancer` struct and related code to use `LoadBalancerNode` instead of `BackendNode`.

- Implemented the `NewLoadBalancer` function to create a new instance of `LoadBalancer` with the given backends.

- Implemented the `Handle` method to handle incoming requests by sending them to the least busy backend.

- Implemented the `getLeastBusyNode` method to return the least busy backend node.

- Added unit tests for the `NewLoadBalancer`, `getLeastBusyNode`, and `Handle` methods.
