### PR TITLE
Improve documentation for using `WithProfilerEndpoint` server option

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -239,6 +239,12 @@ func WithTLS(certFile, keyFile string, config ...*tls.Config) Option {
 // WithProfilerEndpoint is an option function that enables the profiler endpoint for the server.
 // Enabling the profiler endpoint allows profiling and performance monitoring of the server.
 // The profiler endpoint is available at /debug/pprof/.
+// To use the profiler endpoint, import the net/http/pprof package in your application.
+// Example:
+//
+//	import _ "net/http/pprof"
+//
+// The profiler endpoint is disabled by default.
 func WithProfilerEndpoint() Option {
 	return func(s *Server) {
 		s.pprofEnabled = true

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 	"time"
 
+	_ "net/http/pprof" //nolint:gosec // pprof is used for testing profile endpoint
+
 	"github.com/ksysoev/wasabi/mocks"
 )
 
@@ -349,5 +351,18 @@ func TestServer_WithProfilerEndpoint(t *testing.T) {
 	case <-ready:
 	case <-time.After(1 * time.Second):
 		t.Error("Expected server to start")
+	}
+
+	// Check if the profiler endpoint is enabled
+	resp, err := http.Get("http://" + server.Addr().String() + "/debug/pprof/")
+
+	if err != nil {
+		t.Errorf("Got unexpected error: %v", err)
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("Expected status code 200, but got %d", resp.StatusCode)
 	}
 }


### PR DESCRIPTION
Improve documentation for using `WithProfilerEndpoint` server option