### PR TITLE
Handle connection closed errors in backend logic

### DIFF
--- a/backend/http.go
+++ b/backend/http.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/ksysoev/wasabi"
+	"github.com/ksysoev/wasabi/channel"
 )
 
 const defaultTimeout = 30 * time.Second
@@ -78,7 +79,15 @@ func (b *HTTPBackend) Handle(conn wasabi.Connection, r wasabi.Request) error {
 		return err
 	}
 
-	return conn.Send(wasabi.MsgTypeText, body)
+	if err := conn.Send(wasabi.MsgTypeText, body); err != nil {
+		if err == channel.ErrConnectionClosed {
+			return nil
+		}
+
+		return err
+	}
+
+	return nil
 }
 
 // WithTimeout sets the default timeout for the HTTP client.

--- a/backend/queue_test.go
+++ b/backend/queue_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/ksysoev/wasabi"
+	"github.com/ksysoev/wasabi/channel"
 	"github.com/ksysoev/wasabi/mocks"
 	"nhooyr.io/websocket"
 )
@@ -132,6 +133,52 @@ func TestHandle_ErrorSendingRequest(t *testing.T) {
 
 		close(done)
 	}()
+
+	select {
+	case <-done:
+	case <-time.After(1 * time.Second):
+		t.Error("Expected request to be handled")
+	}
+}
+
+func TestHandle_ErrorConnectionClosed(t *testing.T) {
+	expectedData := []byte("request")
+
+	conn := mocks.NewMockConnection(t)
+	conn.EXPECT().Send(websocket.MessageText, expectedData).Return(channel.ErrConnectionClosed)
+
+	r := mocks.NewMockRequest(t)
+	r.EXPECT().Context().Return(context.Background())
+
+	// Create a new QueueBackend instance
+	onRequest := make(chan string)
+	b := NewQueueBackend(func(conn wasabi.Connection, req wasabi.Request, id string) error {
+		onRequest <- id
+		return nil
+	})
+
+	// Call the Handle method
+	done := make(chan struct{})
+	go func() {
+		err := b.Handle(conn, r)
+		if err != nil {
+			t.Errorf("Unexpected error handling request: %v", err)
+		}
+
+		close(done)
+	}()
+
+	var reqID string
+	select {
+	case reqID = <-onRequest:
+		if reqID == "" {
+			t.Error("Expected request ID to be non-empty")
+		}
+	case <-time.After(1 * time.Second):
+		t.Error("Expected request to be handled")
+	}
+
+	b.OnResponse(reqID, websocket.MessageText, expectedData)
 
 	select {
 	case <-done:


### PR DESCRIPTION
This pull request adds error handling for connection closed errors in the backend logic. Previously, when a connection closed error occurred, the error was not properly handled, leading to potential issues. With this change, the code now checks for connection closed errors and handles them appropriately. This improves the reliability and stability of the backend logic.