### PR TITLE
Decommission 1.21 from CI runner

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ["1.21.x", "1.22.x"]
+        go-version: ["1.22.x"]
     steps:
       - uses: actions/checkout@v3
       - name: Setup Go ${{ matrix.go-version }}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ksysoev/wasabi
 
-go 1.22.1
+go 1.21
 
 require (
 	github.com/google/uuid v1.5.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ksysoev/wasabi
 
-go 1.21
+go 1.22.1
 
 require (
 	github.com/google/uuid v1.5.0


### PR DESCRIPTION
Decommission 1.21 from CI runner, because any way it' not in use, in go mod min version is 1.22