### PR TITLE
feat: add predicate for retry middleware

### DIFF
--- a/middleware/request/retry.go
+++ b/middleware/request/retry.go
@@ -8,12 +8,15 @@ import (
 )
 
 // NewRetryMiddleware returns a new retry middleware that wraps the provided `next` request handler.
-// The middleware accepts 2 params consisting of:
+// The middleware accepts 3 params consisting of:
 //   - `getRetryInterval`: A higher order function that returns a function to calculate next retry interval
 //   - `maxRetries`: maximum number of retries allowed for this middleware
+//   - `predicates`: optional function(s) that determine whether the encountered
+//     errors needs retry. If multiple functions are provided, it will be
+//     executed in sequence and stop the moment a function returns false
 //
 // If the request succeeds at any retry, the middleware returns `nil`. If all retries fail, it returns the last error encountered.
-func NewRetryMiddleware(getRetryInterval GetRetryInterval, maxRetries int) func(next wasabi.RequestHandler) wasabi.RequestHandler {
+func NewRetryMiddleware(getRetryInterval GetRetryInterval, maxRetries int, predicates ...func(e error) bool) func(next wasabi.RequestHandler) wasabi.RequestHandler {
 	return func(next wasabi.RequestHandler) wasabi.RequestHandler {
 		return dispatch.RequestHandlerFunc(func(conn wasabi.Connection, req wasabi.Request) error {
 			var err error
@@ -26,6 +29,13 @@ func NewRetryMiddleware(getRetryInterval GetRetryInterval, maxRetries int) func(
 				err = next.Handle(conn, req)
 				if err == nil {
 					return nil
+				}
+
+				for _, pred := range predicates {
+					ok := pred(err)
+					if !ok {
+						return err
+					}
 				}
 
 				ticker.Reset(getRetryInterval(i))


### PR DESCRIPTION
Added an additional optional variadic parameter for NewRetryMiddleware. The parameter accepts a slice of first-level functions that accepts an error argument and return boolean value. Users can specify the function(s) that they want for stopping retry middleware from retrying.

closes #94 