### PR TITLE
Add possibility to provide custom WebSocket dialler

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -27,7 +27,6 @@ linters:
     - dogsled
     - dupl
     - errcheck
-    - exportloopref
     - exhaustive
     - goconst
     - gocritic

--- a/backend/loadbalancer.go
+++ b/backend/loadbalancer.go
@@ -15,7 +15,7 @@ const minRequiredBackends = 2
 type LoadBalancerNode struct {
 	backend wasabi.RequestHandler
 	counter atomic.Int32
-	weight  uint
+	weight  int32
 }
 
 type LoadBalancer struct {
@@ -31,7 +31,7 @@ type LoadBalancer struct {
 // Note: handlers with zero weight will be ignored and will be not considered for load balancing
 func NewLoadBalancer(backends []struct {
 	Handler wasabi.RequestHandler
-	Weight  uint
+	Weight  int32
 }) (*LoadBalancer, error) {
 	if len(backends) < minRequiredBackends {
 		return nil, ErrNotEnoughBackends
@@ -75,7 +75,7 @@ func (lb *LoadBalancer) getLeastBusyNode() *LoadBalancerNode {
 			continue
 		}
 
-		counter := b.counter.Load() / int32(b.weight)
+		counter := b.counter.Load() / b.weight
 
 		if counter < minRequests {
 			minRequests = counter

--- a/backend/loadbalancer_test.go
+++ b/backend/loadbalancer_test.go
@@ -10,7 +10,7 @@ import (
 func TestNewLoadBalancer(t *testing.T) {
 	backends := []struct {
 		Handler wasabi.RequestHandler
-		Weight  uint
+		Weight  int32
 	}{{
 		Handler: mocks.NewMockBackend(t),
 		Weight:  1,
@@ -23,7 +23,7 @@ func TestNewLoadBalancer(t *testing.T) {
 
 	backends = append(backends, struct {
 		Handler wasabi.RequestHandler
-		Weight  uint
+		Weight  int32
 	}{mocks.NewMockBackend(t), 1})
 
 	lb, err := NewLoadBalancer(backends)
@@ -49,7 +49,7 @@ func TestNewLoadBalancer(t *testing.T) {
 func TestLoadBalancer_getLeastBusyNode(t *testing.T) {
 	backends := []struct {
 		Handler wasabi.RequestHandler
-		Weight  uint
+		Weight  int32
 	}{{
 		Handler: mocks.NewMockBackend(t),
 		Weight:  1,
@@ -78,7 +78,7 @@ func TestLoadBalancer_getLeastBusyNode(t *testing.T) {
 func TestLoadBalancer_getLeastBusyNodeWeighted(t *testing.T) {
 	backends := []struct {
 		Handler wasabi.RequestHandler
-		Weight  uint
+		Weight  int32
 	}{{
 		Handler: mocks.NewMockBackend(t),
 		Weight:  1,
@@ -108,7 +108,7 @@ func TestLoadBalancer_getLeastBusyNodeWeighted(t *testing.T) {
 func TestLoadBalancer_getLeastBusyNodeZeroWeight(t *testing.T) {
 	backends := []struct {
 		Handler wasabi.RequestHandler
-		Weight  uint
+		Weight  int32
 	}{{
 		Handler: mocks.NewMockBackend(t),
 		Weight:  0,
@@ -134,13 +134,13 @@ func TestLoadBalancer_getLeastBusyNodeZeroWeight(t *testing.T) {
 func TestLoadBalancer_Handle(t *testing.T) {
 	firstBackend := struct {
 		Handler wasabi.RequestHandler
-		Weight  uint
+		Weight  int32
 	}{Handler: mocks.NewMockBackend(t), Weight: 1}
 
 	// Create mock backends for testing
 	backends := []struct {
 		Handler wasabi.RequestHandler
-		Weight  uint
+		Weight  int32
 	}{firstBackend, {
 		Handler: mocks.NewMockBackend(t),
 		Weight:  1,

--- a/backend/ws.go
+++ b/backend/ws.go
@@ -21,20 +21,20 @@ type WSBackend struct {
 	connections map[string]*websocket.Conn
 	lock        *sync.RWMutex
 	factory     WSRequestFactory
-	URL         string
 	dialer      WSDialler
+	URL         string
 }
 
 type WSRequestFactory func(r wasabi.Request) (websocket.MessageType, []byte, error)
 
 // NewWSBackend creates a new instance of WSBackend with the specified URL.
-func NewWSBackend(base_url string, factory WSRequestFactory, opts ...WSBackendOptions) *WSBackend {
+func NewWSBackend(baseURL string, factory WSRequestFactory, opts ...WSBackendOptions) *WSBackend {
 	b := &WSBackend{
 		group:       &singleflight.Group{},
 		connections: make(map[string]*websocket.Conn),
 		lock:        &sync.RWMutex{},
 		factory:     factory,
-		URL:         base_url,
+		URL:         baseURL,
 		dialer:      dialler,
 	}
 

--- a/backend/ws.go
+++ b/backend/ws.go
@@ -77,14 +77,9 @@ func (b *WSBackend) getConnection(conn wasabi.Connection) (*websocket.Conn, erro
 	}
 
 	uws, err, _ := b.group.Do(conn.ID(), func() (interface{}, error) {
-		c, resp, err := websocket.Dial(conn.Context(), b.URL, nil)
-
+		c, err := b.dialer(conn.Context(), b.URL)
 		if err != nil {
 			return nil, err
-		}
-
-		if resp.Body != nil {
-			defer resp.Body.Close()
 		}
 
 		go b.responseHandler(c, conn)
@@ -161,6 +156,9 @@ func (b *WSBackend) responseHandler(server *websocket.Conn, client wasabi.Connec
 	err = ctx.Err()
 }
 
+// dialler is a default implementation of the WSDialler interface.
+// It establishes a new WebSocket connection with the given base URL.
+// The function returns the connection and an error if there is any issue with the connection.
 func dialler(ctx context.Context, baseURL string) (*websocket.Conn, error) {
 	c, resp, err := websocket.Dial(ctx, baseURL, nil)
 
@@ -175,6 +173,8 @@ func dialler(ctx context.Context, baseURL string) (*websocket.Conn, error) {
 	return c, nil
 }
 
+// WithWSDialler sets the dialer for the WebSocket backend.
+// It takes a WSDialler function as a parameter and returns a WSBackendOptions function.
 func WithWSDialler(dialer WSDialler) WSBackendOptions {
 	return func(b *WSBackend) {
 		b.dialer = dialer

--- a/backend/ws.go
+++ b/backend/ws.go
@@ -2,8 +2,8 @@ package backend
 
 import (
 	"bytes"
+	"context"
 	"errors"
-	"fmt"
 	"io"
 	"sync"
 
@@ -12,25 +12,37 @@ import (
 	"golang.org/x/sync/singleflight"
 )
 
+type WSBackendOptions func(*WSBackend)
+
+type WSDialler func(ctx context.Context, baseURL string) (*websocket.Conn, error)
+
 type WSBackend struct {
 	group       *singleflight.Group
 	connections map[string]*websocket.Conn
 	lock        *sync.RWMutex
 	factory     WSRequestFactory
 	URL         string
+	dialer      WSDialler
 }
 
 type WSRequestFactory func(r wasabi.Request) (websocket.MessageType, []byte, error)
 
 // NewWSBackend creates a new instance of WSBackend with the specified URL.
-func NewWSBackend(url string, factory WSRequestFactory) *WSBackend {
-	return &WSBackend{
+func NewWSBackend(base_url string, factory WSRequestFactory, opts ...WSBackendOptions) *WSBackend {
+	b := &WSBackend{
 		group:       &singleflight.Group{},
 		connections: make(map[string]*websocket.Conn),
 		lock:        &sync.RWMutex{},
 		factory:     factory,
-		URL:         url,
+		URL:         base_url,
+		dialer:      dialler,
 	}
+
+	for _, opt := range opts {
+		opt(b)
+	}
+
+	return b
 }
 
 // Handle handles the incoming request from the WebSocket connection.
@@ -65,7 +77,6 @@ func (b *WSBackend) getConnection(conn wasabi.Connection) (*websocket.Conn, erro
 	}
 
 	uws, err, _ := b.group.Do(conn.ID(), func() (interface{}, error) {
-		fmt.Println("Connecting to", b.URL, "for connection", conn.ID())
 		c, resp, err := websocket.Dial(conn.Context(), b.URL, nil)
 
 		if err != nil {
@@ -148,4 +159,24 @@ func (b *WSBackend) responseHandler(server *websocket.Conn, client wasabi.Connec
 	}
 
 	err = ctx.Err()
+}
+
+func dialler(ctx context.Context, baseURL string) (*websocket.Conn, error) {
+	c, resp, err := websocket.Dial(ctx, baseURL, nil)
+
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.Body != nil {
+		defer resp.Body.Close()
+	}
+
+	return c, nil
+}
+
+func WithWSDialler(dialer WSDialler) WSBackendOptions {
+	return func(b *WSBackend) {
+		b.dialer = dialer
+	}
 }

--- a/backend/ws_test.go
+++ b/backend/ws_test.go
@@ -262,7 +262,7 @@ func TestWSBackend_RequestFactory_Error(t *testing.T) {
 	}
 }
 func TestWithWSDialler(t *testing.T) {
-	customDialer := func(ctx context.Context, baseURL string) (*websocket.Conn, error) {
+	customDialer := func(_ context.Context, _ string) (*websocket.Conn, error) {
 		return nil, assert.AnError
 	}
 


### PR DESCRIPTION
This pull request adds the ability to provide a custom WebSocket dialler to the WSBackend. It introduces a new `WSDialler` type and a `dialler` function that can be used to establish a WebSocket connection. The `NewWSBackend` function now accepts an optional `WSBackendOptions` parameter that allows users to pass in a custom dialler. This enhancement provides more flexibility and customization options for establishing WebSocket connections in the backend.