### PR TITLE
Fix internal server error when dialing websocket connection

### DIFF
--- a/backend/ws.go
+++ b/backend/ws.go
@@ -79,6 +79,7 @@ func (b *WSBackend) getConnection(conn wasabi.Connection) (*websocket.Conn, erro
 	uws, err, _ := b.group.Do(conn.ID(), func() (interface{}, error) {
 		c, err := b.dialer(conn.Context(), b.URL)
 		if err != nil {
+			_ = conn.Close(websocket.StatusInternalError, "Internal Server Error")
 			return nil, err
 		}
 

--- a/backend/ws_test.go
+++ b/backend/ws_test.go
@@ -130,6 +130,7 @@ func TestGetConnectionDialError(t *testing.T) {
 	conn := mocks.NewMockConnection(t)
 	conn.EXPECT().ID().Return("connection1")
 	conn.EXPECT().Context().Return(context.Background())
+	conn.EXPECT().Close(websocket.StatusInternalError, "Internal Server Error").Return(nil)
 
 	_, err := b.getConnection(conn)
 	if err == nil {
@@ -182,6 +183,7 @@ func TestWSBackend_Handle_FailToConnect(t *testing.T) {
 	conn := mocks.NewMockConnection(t)
 	conn.EXPECT().ID().Return("connection1")
 	conn.EXPECT().Context().Return(context.Background())
+	conn.EXPECT().Close(websocket.StatusInternalError, "Internal Server Error").Return(nil)
 
 	r := mocks.NewMockRequest(t)
 


### PR DESCRIPTION
This pull request fixes an issue where an internal server error was occurring when dialing a websocket connection. The fix ensures that the connection is properly closed and returns an error when the dialing process encounters an error.