### PR TITLE
chore: bump golang version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ksysoev/wasabi
 
-go 1.22.1
+go 1.23.4
 
 require (
 	github.com/coder/websocket v1.8.12


### PR DESCRIPTION
This PR bumps Golang version to the latest `1.23.4` Closes #152 

I noticed `golangci-lint` might stop working when there is a major version bump. Shall I include a Docker command to run lint using `docker`?