### PR TITLE
Update Go version and golangci-lint in CI workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Code Lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.64.8s
+          version: v1.64.8
       - name: Build
         run: go build -v ./...
       - name: Test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: ["1.22.x"]
+        go-version: ["1.24.x"]
     steps:
       - uses: actions/checkout@v4
       - name: Setup Go ${{ matrix.go-version }}
@@ -27,7 +27,7 @@ jobs:
       - name: Code Lint
         uses: golangci/golangci-lint-action@v6
         with:
-          version: v1.60.1
+          version: v1.64.8s
       - name: Build
         run: go build -v ./...
       - name: Test

--- a/backend/http_test.go
+++ b/backend/http_test.go
@@ -181,15 +181,26 @@ func TestWithMaxRequestsPerHost(t *testing.T) {
 
 	backend := NewBackend(nil, WithMaxRequestsPerHost(maxReqPerHost))
 
-	if backend.client.Transport.(*http.Transport).MaxConnsPerHost != maxReqPerHost {
-		t.Errorf("Expected MaxConnsPerHost to be %v, but got %v", maxReqPerHost, backend.client.Transport.(*http.Transport).MaxConnsPerHost)
+	tr, ok := backend.client.Transport.(*http.Transport)
+
+	if !ok {
+		t.Errorf("Expected client transport to be *http.Transport, but got %T", backend.client.Transport)
+	}
+
+	if tr.MaxConnsPerHost != maxReqPerHost {
+		t.Errorf("Expected MaxConnsPerHost to be %v, but got %v", maxReqPerHost, tr.MaxConnsPerHost)
 	}
 }
 
 func TestWithMaxRequestsPerHost_DefaultValue(t *testing.T) {
 	backend := NewBackend(nil)
 
-	if backend.client.Transport.(*http.Transport).MaxConnsPerHost != defaultMaxReqPerHost {
-		t.Errorf("Expected MaxConnsPerHost to be %v, but got %v", defaultMaxReqPerHost, backend.client.Transport.(*http.Transport).MaxConnsPerHost)
+	tr, ok := backend.client.Transport.(*http.Transport)
+	if !ok {
+		t.Errorf("Expected client transport to be *http.Transport, but got %T", backend.client.Transport)
+	}
+
+	if tr.MaxConnsPerHost != defaultMaxReqPerHost {
+		t.Errorf("Expected MaxConnsPerHost to be %v, but got %v", defaultMaxReqPerHost, tr.MaxConnsPerHost)
 	}
 }

--- a/backend/loadbalancer_test.go
+++ b/backend/loadbalancer_test.go
@@ -132,10 +132,12 @@ func TestLoadBalancer_getLeastBusyNodeZeroWeight(t *testing.T) {
 }
 
 func TestLoadBalancer_Handle(t *testing.T) {
+	mockBackend := mocks.NewMockBackend(t)
+
 	firstBackend := struct {
 		Handler wasabi.RequestHandler
 		Weight  int32
-	}{Handler: mocks.NewMockBackend(t), Weight: 1}
+	}{Handler: mockBackend, Weight: 1}
 
 	// Create mock backends for testing
 	backends := []struct {
@@ -158,7 +160,7 @@ func TestLoadBalancer_Handle(t *testing.T) {
 	mockConn := mocks.NewMockConnection(t)
 	mockRequest := mocks.NewMockRequest(t)
 
-	firstBackend.Handler.(*mocks.MockBackend).EXPECT().Handle(mockConn, mockRequest).Return(nil)
+	mockBackend.EXPECT().Handle(mockConn, mockRequest).Return(nil)
 
 	// Call the Handle method
 	err = lb.Handle(mockConn, mockRequest)

--- a/channel/buffers.go
+++ b/channel/buffers.go
@@ -20,7 +20,8 @@ func newBufferPool() *bufferPool {
 }
 
 func (p *bufferPool) get() *bytes.Buffer {
-	return p.pool.Get().(*bytes.Buffer)
+	b, _ := p.pool.Get().(*bytes.Buffer)
+	return b
 }
 
 func (p *bufferPool) put(b *bytes.Buffer) {

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ksysoev/wasabi
 
-go 1.23.4
+go 1.24.1
 
 require (
 	github.com/coder/websocket v1.8.13

--- a/middleware/request/retry_test.go
+++ b/middleware/request/retry_test.go
@@ -112,6 +112,8 @@ func TestNewRetryMiddleware_CancelledContext_WithExponentialRetryPolicy(t *testi
 
 	// Create a mock request handler
 	mockHandler := dispatch.RequestHandlerFunc(func(_ wasabi.Connection, _ wasabi.Request) error {
+		time.Sleep(10 * time.Millisecond)
+
 		return fmt.Errorf("mock error")
 	})
 


### PR DESCRIPTION
Upgrade the Go version to 1.24.x and update golangci-lint to v1.64.8 in the GitHub Actions workflow for improved performance and linting capabilities.